### PR TITLE
Rename `delim` to `sep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A derive macro-based library for flexible syntax tree formatting with pretty pri
 ## Features
 
 - **Derive Macro** - Automatic implementation via `#[derive(SyntaxFmt)]`
-- **Flexible Decorations** - Add prefixes, suffixes, and collection delimiters
+- **Flexible Decorations** - Add prefixes, suffixes, and collection separators
 - **Modal Formatting** - Customise formatting output for different modes, normal and pretty
 - **Automatic Layout** - Automated layout control with newlines and indentation
 - **Content Replacement** - Override field formatting with literals or custom functions
@@ -80,7 +80,7 @@ use syntaxfmt::{SyntaxFmt, syntax_fmt};
 struct FunctionCall<'src> {
     name: &'src str,
 
-    #[syntax(pre = ["(", "( "], suf = [")", " )"], delim = [", ", ",  "])]
+    #[syntax(pre = ["(", "( "], suf = [")", " )"], sep = [", ", ",  "])]
     args: Vec<&'src str>,
 }
 
@@ -107,7 +107,7 @@ Attributes can be applied at the type, field, or `syntax_else` level.
 |----------|-------------|----------------|
 | `pre` | Text before content | field/type/else |
 | `suf` | Text after content | field/type/else |
-| `delim` | Separator between collection elements | field/type/else |
+| `sep` | Separator between collection elements | field/type/else |
 | `cont` | Literal replacement for field value | field/type/else |
 | `cont_with` | Custom formatter function/closure | field/type/else |
 | `eval` | Conditional expression | field/type |

--- a/crates/syntaxfmt-macros/src/attributes.rs
+++ b/crates/syntaxfmt-macros/src/attributes.rs
@@ -1,6 +1,6 @@
 pub mod args;
 pub mod content;
-pub mod delims;
+pub mod seps;
 pub mod eval;
 pub mod modal;
 pub mod prefix_suffix;

--- a/crates/syntaxfmt-macros/src/attributes/args.rs
+++ b/crates/syntaxfmt-macros/src/attributes/args.rs
@@ -8,7 +8,7 @@ use syn::{
 use crate::{
     attributes::{
         content::{Content, Skipped, WithCommon, WithConditional, WithEval},
-        delims::PushDelims,
+        seps::PushSeps,
         eval::Eval,
         prefix_suffix::{Prefix, Suffix},
         pretty::{Newlines, PushIndentRegion},
@@ -23,7 +23,7 @@ pub enum ArgType {
     Newline,
     Prefix,
     Suffix,
-    Delim,
+    Sep,
     Eval,
     Cont,
     Bound,
@@ -44,7 +44,7 @@ pub trait TakeArgs: Sized {
             "nl" => ArgType::Newline,
             "pre" => ArgType::Prefix,
             "suf" => ArgType::Suffix,
-            "delim" => ArgType::Delim,
+            "sep" => ArgType::Sep,
             "eval" | "eval_with" => ArgType::Eval,
             "cont" | "cont_with" => ArgType::Cont,
             "bound" => ArgType::Bound,
@@ -59,7 +59,7 @@ pub trait TakeArgs: Sized {
 pub struct CommonArgs {
     pub prefix: Option<Prefix>,
     pub suffix: Option<Suffix>,
-    pub delims: Option<PushDelims>,
+    pub seps: Option<PushSeps>,
     pub content: Option<Content>,
     pub indent: Option<PushIndentRegion>,
     pub nl: Newlines,
@@ -74,7 +74,7 @@ impl CommonArgs {
             Indent(_)
                 | Prefix(_)
                 | Suffix(_)
-                | Delims(_)
+                | Seps(_)
                 | Content(_)
                 | ContentTypePath(_)
                 | ContentClosure(_)
@@ -100,7 +100,7 @@ impl TakeArgs for CommonArgs {
                 match arg.kind {
                     Kind::Prefix(i) => self.prefix = Prefix::from_litstrs(i)?,
                     Kind::Suffix(i) => self.suffix = Suffix::from_litstrs(i)?,
-                    Kind::Delims(i) => self.delims = PushDelims::from_litstrs(i)?,
+                    Kind::Seps(i) => self.seps = PushSeps::from_litstrs(i)?,
                     Kind::Content(i) => self.content = Content::from_expr(i)?,
                     Kind::ContentTypePath(i) => self.content = Content::from_type_path(i)?,
                     Kind::ContentClosure(i) => self.content = Content::from_closure(i)?,

--- a/crates/syntaxfmt-macros/src/attributes/content.rs
+++ b/crates/syntaxfmt-macros/src/attributes/content.rs
@@ -5,7 +5,7 @@ use quote::{ToTokens, quote};
 use syn::{Expr, ExprClosure, Ident, Result as SynResult, TypePath};
 
 use crate::{
-    attributes::{args::CommonArgs, delims::PopDelims, eval::Eval, pretty::PopIndentRegion},
+    attributes::{args::CommonArgs, seps::PopSeps, eval::Eval, pretty::PopIndentRegion},
     syn_err,
 };
 
@@ -58,8 +58,8 @@ where
         let prefix = &common.prefix;
         let suffix = &common.suffix;
 
-        let (push_delims, pop_delims) = if let Some(delims) = &common.delims {
-            (Some(delims), Some(PopDelims))
+        let (push_seps, pop_seps) = if let Some(seps) = &common.seps {
+            (Some(seps), Some(PopSeps))
         } else {
             Default::default()
         };
@@ -83,8 +83,8 @@ where
 
         // Push and pop indent has to be in non-symmetric location
         // This is because indenting is non-symmetric
-        let pre = quote! { #nl_begin #prefix #push_indent #nl_prefix #push_delims };
-        let post = quote! { #pop_delims #pop_indent #nl_content #suffix #nl_suffix };
+        let pre = quote! { #nl_begin #prefix #push_indent #nl_prefix #push_seps };
+        let post = quote! { #pop_seps #pop_indent #nl_content #suffix #nl_suffix };
 
         quote! { #pre #content #post }
     }

--- a/crates/syntaxfmt-macros/src/attributes/seps.rs
+++ b/crates/syntaxfmt-macros/src/attributes/seps.rs
@@ -5,32 +5,32 @@ use syn::{LitStr, Result as SynResult, punctuated::Punctuated, token::Comma};
 use crate::attributes::modal::Strings;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct PushDelims(pub Strings);
+pub struct PushSeps(pub Strings);
 
-impl PushDelims {
+impl PushSeps {
     pub fn from_litstrs(litstrs: Punctuated<LitStr, Comma>) -> SynResult<Option<Self>> {
         Ok(Some(Self(Strings::from_litstrs(litstrs)?)))
     }
 }
 
-impl ToTokens for PushDelims {
+impl ToTokens for PushSeps {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         let strs = &self.0;
-        tokens.extend(quote! { f.push_delim(#strs); });
+        tokens.extend(quote! { f.push_sep(#strs); });
     }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct PopDelims;
+pub struct PopSeps;
 
-impl ToTokens for PopDelims {
+impl ToTokens for PopSeps {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        tokens.extend(quote! { f.pop_delim(); });
+        tokens.extend(quote! { f.pop_sep(); });
     }
 }
 
-impl<'a> From<&'a PushDelims> for PopDelims {
-    fn from(_: &'a PushDelims) -> Self {
+impl<'a> From<&'a PushSeps> for PopSeps {
+    fn from(_: &'a PushSeps) -> Self {
         Self
     }
 }

--- a/crates/syntaxfmt-macros/src/attributes/unverified_args.rs
+++ b/crates/syntaxfmt-macros/src/attributes/unverified_args.rs
@@ -17,7 +17,7 @@ pub enum UnverifiedArgKind {
     Newlines(Punctuated<Ident, Comma>),
     Prefix(Punctuated<LitStr, Comma>),
     Suffix(Punctuated<LitStr, Comma>),
-    Delims(Punctuated<LitStr, Comma>),
+    Seps(Punctuated<LitStr, Comma>),
     Eval(Expr),
     EvalTypePath(TypePath),
     EvalClosure(ExprClosure),
@@ -36,7 +36,7 @@ impl ToTokens for UnverifiedArgKind {
             Self::Newlines(i) => i.to_tokens(tokens),
             Self::Prefix(i) => i.to_tokens(tokens),
             Self::Suffix(i) => i.to_tokens(tokens),
-            Self::Delims(i) => i.to_tokens(tokens),
+            Self::Seps(i) => i.to_tokens(tokens),
             Self::Eval(i) => i.to_tokens(tokens),
             Self::EvalTypePath(i) => i.to_tokens(tokens),
             Self::EvalClosure(i) => i.to_tokens(tokens),
@@ -169,12 +169,12 @@ impl Parse for UnverifiedArgs {
                     ident,
                     kind: UnverifiedArgKind::Suffix(strs),
                 });
-            } else if ident == "delim" {
+            } else if ident == "sep" {
                 input.parse::<SynEq>()?;
                 let strs = Self::parse_litstrs(&mut input)?;
                 attrs.push(UnverifiedArg {
                     ident,
-                    kind: UnverifiedArgKind::Delims(strs),
+                    kind: UnverifiedArgKind::Seps(strs),
                 });
             } else if ident == "eval" {
                 input.parse::<SynEq>()?;

--- a/crates/syntaxfmt-macros/src/attributes/unverified_args.rs
+++ b/crates/syntaxfmt-macros/src/attributes/unverified_args.rs
@@ -176,6 +176,8 @@ impl Parse for UnverifiedArgs {
                     ident,
                     kind: UnverifiedArgKind::Seps(strs),
                 });
+            } else if ident == "delim" {
+                return syn_err(&ident, "syntaxfmt `delim` has been replaced by `sep`. Please replace your references. Usage is the same.");
             } else if ident == "eval" {
                 input.parse::<SynEq>()?;
                 let expr = input.parse::<Expr>()?;

--- a/crates/syntaxfmt-macros/tests/basic.rs
+++ b/crates/syntaxfmt-macros/tests/basic.rs
@@ -335,64 +335,64 @@ fn test_outer_content_modal_slice() {
 }
 
 // =============================================================================
-// delim
+// sep
 // =============================================================================
 
 #[derive(SyntaxFmtDerive)]
-struct DelimItem(&'static str);
+struct SepItem(&'static str);
 
 #[derive(SyntaxFmtDerive)]
-struct WithDefaultDelim {
-    items: Vec<DelimItem>,
+struct WithDefaultSep {
+    items: Vec<SepItem>,
 }
 
 #[test]
-fn test_default_delim() {
-    let s = WithDefaultDelim {
-        items: vec![DelimItem("a"), DelimItem("b"), DelimItem("c")],
+fn test_default_sep() {
+    let s = WithDefaultSep {
+        items: vec![SepItem("a"), SepItem("b"), SepItem("c")],
     };
     assert_eq!(format!("{}", syntax_fmt(&s)), "a,b,c");
 }
 
 #[derive(SyntaxFmtDerive)]
-struct WithDelim {
-    #[syntax(delim = "|")]
-    items: Vec<DelimItem>,
+struct WithSep {
+    #[syntax(sep = "|")]
+    items: Vec<SepItem>,
 }
 
 #[test]
-fn test_delim() {
-    let s = WithDelim {
-        items: vec![DelimItem("a"), DelimItem("b"), DelimItem("c")],
+fn test_sep() {
+    let s = WithSep {
+        items: vec![SepItem("a"), SepItem("b"), SepItem("c")],
     };
     assert_eq!(format!("{}", syntax_fmt(&s)), "a|b|c");
 }
 
 #[derive(SyntaxFmtDerive)]
-struct WithModalDelim {
-    #[syntax(delim = [":", ": "])]
-    items: Vec<DelimItem>,
+struct WithModalSep {
+    #[syntax(sep = [":", ": "])]
+    items: Vec<SepItem>,
 }
 
 #[test]
-fn test_modal_delim() {
-    let s = WithModalDelim {
-        items: vec![DelimItem("a"), DelimItem("b"), DelimItem("c")],
+fn test_modal_sep() {
+    let s = WithModalSep {
+        items: vec![SepItem("a"), SepItem("b"), SepItem("c")],
     };
     assert_eq!(format!("{}", syntax_fmt(&s)), "a:b:c");
     assert_eq!(format!("{}", syntax_fmt(&s).pretty()), "a: b: c");
 }
 
 #[derive(SyntaxFmtDerive)]
-#[syntax(delim = "|")]
-struct WithOuterDelim {
-    items: Vec<DelimItem>,
+#[syntax(sep = "|")]
+struct WithOuterSep {
+    items: Vec<SepItem>,
 }
 
 #[test]
-fn test_outer_delim() {
-    let s = WithOuterDelim {
-        items: vec![DelimItem("a"), DelimItem("b"), DelimItem("c")],
+fn test_outer_sep() {
+    let s = WithOuterSep {
+        items: vec![SepItem("a"), SepItem("b"), SepItem("c")],
     };
     assert_eq!(format!("{}", syntax_fmt(&s)), "a|b|c");
 }

--- a/crates/syntaxfmt-macros/tests/integration.rs
+++ b/crates/syntaxfmt-macros/tests/integration.rs
@@ -20,7 +20,7 @@ struct Param {
 
 #[derive(SyntaxFmtDerive)]
 struct Block {
-    #[syntax(pre = " {", suf = "}", nl = cont, ind, delim = "")]
+    #[syntax(pre = " {", suf = "}", nl = cont, ind, sep = "")]
     statements: Vec<Statement>,
 }
 
@@ -56,8 +56,8 @@ struct Function {
     #[syntax(pre = "fn ")]
     name: Ident,
 
-    // Parameters with delimiters and wrapping
-    #[syntax(pre = "(", suf = ")", delim = ", ")]
+    // Parameters with separators and wrapping
+    #[syntax(pre = "(", suf = ")", sep = ", ")]
     params: Vec<Param>,
 
     // Optional return type

--- a/examples/comprehensive.rs
+++ b/examples/comprehensive.rs
@@ -48,7 +48,7 @@ enum Expr<'src> {
 struct FunctionCall<'src> {
     name: &'src str,
 
-    #[syntax(pre = "(", suf = ")", delim = [", ", ", "])]
+    #[syntax(pre = "(", suf = ")", sep = [", ", ", "])]
     args: Vec<Expr<'src>>,
 }
 
@@ -94,7 +94,7 @@ enum Statement<'src> {
 #[derive(SyntaxFmt)]
 #[syntax(pre = "{", suf = "}", bound = TypeDisplay)]
 struct Block<'src> {
-    #[syntax(nl = [cont], ind, delim = "")]
+    #[syntax(nl = [cont], ind, sep = "")]
     statements: Vec<Statement<'src>>,
 }
 
@@ -104,7 +104,7 @@ struct Block<'src> {
 struct Function<'src> {
     name: &'src str,
 
-    #[syntax(pre = "(", suf = ")", delim = [", ", ", "])]
+    #[syntax(pre = "(", suf = ")", sep = [", ", ", "])]
     params: Vec<Parameter<'src>>,
 
     #[syntax(pre = " -> ", eval = return_type.is_some())]


### PR DESCRIPTION
`delim` is currently for specifying separators, eg the `|` in `itemA|itemB|itemC`. 

This is the wrong terminology - delimiters are usually the surrounding content, eg the `{` and `}` in `{stuff here}`.

# Summary
* Rename `delim` to `sep`